### PR TITLE
fix: 管理界面追加执行时间不起作用

### DIFF
--- a/boc_announcement_monitor/admin.py
+++ b/boc_announcement_monitor/admin.py
@@ -190,6 +190,23 @@ HTML_TEMPLATE = """
 """
 
 
+def normalize_time(time_str: str) -> str:
+    """Normalize time format by removing leading zeros from hour.
+
+    Args:
+        time_str: Time string in "HH:MM" format
+
+    Returns:
+        Normalized time string like "9:30" instead of "09:30"
+    """
+    parts = time_str.split(":")
+    if len(parts) == 2:
+        hour = int(parts[0])
+        minute = parts[1]
+        return f"{hour}:{minute}"
+    return time_str
+
+
 def load_config() -> dict:
     """Load schedule configuration from file."""
     config_path = Path(CONFIG_FILE)
@@ -216,20 +233,32 @@ def update_cron(config: dict) -> None:
     times = config["times"]
     weekdays = ",".join(str(d) for d in config["weekdays"])
 
-    hours_minutes = []
+    # Group hours by minute for correct cron syntax
+    # e.g., "9:30" and "11:30" -> minute 30, hours [9, 11] -> "30 9,11"
+    minute_hours: dict[str, list[int]] = {}
     for t in times:
         parts = t.split(":")
         if len(parts) == 2:
-            hours_minutes.append(f"{parts[1]} {parts[0]}")
+            minute = parts[1]
+            hour = int(parts[0])
+            if minute not in minute_hours:
+                minute_hours[minute] = []
+            if hour not in minute_hours[minute]:
+                minute_hours[minute].append(hour)
 
-    if not hours_minutes:
+    if not minute_hours:
         subprocess.run(["crontab", "-r"], capture_output=True)
         return
 
-    time_spec = ",".join(hours_minutes)
-    cron_line = f"{time_spec} * * {weekdays} cd /app && {PYTHON_PATH} main.py >> /app/data/logs/cron.log 2>&1\n"
+    cron_lines = []
+    for minute, hours in minute_hours.items():
+        hours_str = ",".join(str(h) for h in sorted(hours))
+        cron_lines.append(
+            f"{minute} {hours_str} * * {weekdays} cd /app && {PYTHON_PATH} main.py >> /app/data/logs/cron.log 2>&1"
+        )
 
-    subprocess.run(["crontab", "-"], input=cron_line.encode(), capture_output=True)
+    cron_content = "\n".join(cron_lines) + "\n"
+    subprocess.run(["crontab", "-"], input=cron_content.encode(), capture_output=True)
 
 
 def get_logs() -> str:
@@ -279,11 +308,11 @@ def set_enabled():
 @app.route("/api/schedule/times", methods=["POST"])
 def add_schedule_time():
     data = request.get_json()
-    time_str = data.get("time", "")
+    time_str = normalize_time(data.get("time", ""))
     config = load_config()
     if time_str and time_str not in config["times"]:
         config["times"].append(time_str)
-        config["times"].sort()
+        config["times"].sort(key=lambda t: int(t.split(":")[0]) * 60 + int(t.split(":")[1]))
         save_config(config)
         update_cron(config)
     return jsonify({"success": True})
@@ -292,7 +321,7 @@ def add_schedule_time():
 @app.route("/api/schedule/times", methods=["DELETE"])
 def remove_schedule_time():
     data = request.get_json()
-    time_str = data.get("time", "")
+    time_str = normalize_time(data.get("time", ""))
     config = load_config()
     if time_str in config["times"]:
         config["times"].remove(time_str)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -19,15 +19,26 @@ config = json.load(open('/app/data/schedule_config.json'))
 if config.get('enabled', True):
     times = config.get('times', [])
     weekdays = ','.join(str(d) for d in config.get('weekdays', [1,2,3,4,5]))
-    hours_minutes = []
+
+    # Group hours by minute for correct cron syntax
+    minute_hours = {}
     for t in times:
         parts = t.split(':')
         if len(parts) == 2:
-            hours_minutes.append(f'{parts[1]} {parts[0]}')
-    if hours_minutes:
-        time_spec = ','.join(hours_minutes)
-        cron_line = f'{time_spec} * * {weekdays} cd /app && /usr/local/bin/python main.py >> /app/data/logs/cron.log 2>&1\n'
-        subprocess.run(['crontab', '-'], input=cron_line.encode())
+            minute = parts[1]
+            hour = int(parts[0])
+            if minute not in minute_hours:
+                minute_hours[minute] = []
+            if hour not in minute_hours[minute]:
+                minute_hours[minute].append(hour)
+
+    if minute_hours:
+        cron_lines = []
+        for minute, hours in minute_hours.items():
+            hours_str = ','.join(str(h) for h in sorted(hours))
+            cron_lines.append(f'{minute} {hours_str} * * {weekdays} cd /app && /usr/local/bin/python main.py >> /app/data/logs/cron.log 2>&1')
+        cron_content = chr(10).join(cron_lines) + chr(10)
+        subprocess.run(['crontab', '-'], input=cron_content.encode())
 "
 
 # Start admin web server in background


### PR DESCRIPTION
## 变更概述

修复管理界面添加执行时间后，定时任务不执行的问题。

## 问题原因

`update_cron` 函数生成的 cron 语法错误：

**错误的 cron 格式**（之前）：
```
30 9,30 11,30 14 * * 1-5 ...
```
这会被解析为：分钟 (30或9)，小时 (30或11)，而不是预期的多个时间点。

**正确的 cron 格式**（修复后）：
```
30 9,11,14 * * 1-5 ...
```
这会被正确解析为：分钟 30，小时 9、11、14。

## 关键实现

- 修改 `update_cron()` 函数，按分钟分组小时值
- 添加 `normalize_time()` 函数，处理 HTML 输入的前导零问题
- 修复时间排序，使用数值排序代替字典排序
- 同步更新 `entrypoint.sh` 中的 cron 初始化逻辑

## 示例

添加执行时间 "9:30", "11:30", "14:30" 后：

| 时间 | cron 行 |
|------|---------|
| 9:30, 11:30, 14:30 | `30 9,11,14 * * 1-5 ...` |

如果添加不同分钟的时间（如 "10:00"），会生成多行：
```
30 9,11,14 * * 1-5 ...
0 10 * * 1-5 ...
```

## 相关链接

- Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)